### PR TITLE
fix RFC1912 and RFC7477 serial violation

### DIFF
--- a/providers/zone.rb
+++ b/providers/zone.rb
@@ -72,7 +72,7 @@ def serial(zone_name = new_resource.zone_name)
 end
 
 def new_serial
-  DateTime.now.strftime('%Y%m%d%H%M%S')
+  DateTime.now.strftime('%Y%m%d%H')
 end
 
 def reversed_records


### PR DESCRIPTION
From RFC7477:
> 2.1.1.1.  The SOA Serial Field
> 
>    The SOA Serial field contains a copy of the 32-bit SOA serial number
>    from the child zone.  If the soaminimum flag is set, parental agents
>    querying children's authoritative servers MUST NOT act on data from
>    zones advertising an SOA serial number less than this value.  See
>    [RFC1982] for properly implementing "less than" logic.

the generated serial number is > the unsigned 32 bit integer...general practice is something closer to `YYYYMMDDxx`, where xx=daily revision.  This won't overflow until the year 4294.

This "fix" is a hack and needs to be revisited, but in the short term will let it work...once per hour.